### PR TITLE
Fix organization key config

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,8 +21,8 @@ You can configure openai in your mix config.exs (default $project_root/config/co
 use Mix.Config
 
 config :openai,
-  api_key: "your-api-key" # find it at https://beta.openai.com/account/api-keys
-  orgainization_key: "your-organization-key" # find it at https://beta.openai.com/account/api-keys
+  api_key: "your-api-key", # find it at https://beta.openai.com/account/api-keys
+  organization_key: "your-organization-key" # find it at https://beta.openai.com/account/api-keys
 
 ```
 

--- a/lib/openai/client.ex
+++ b/lib/openai/client.ex
@@ -26,12 +26,11 @@ defmodule OpenAI.Client do
   end
 
   def add_organization_header(headers) do
-    unless Config.org_key() == nil do
+    if Config.org_key() do
+      [{"OpenAI-Organization", Config.org_key()} | headers]
+    else
       headers
-      |> Enum.concat({"OpenAI-Organization", Config.org_key()})
     end
-
-    headers
   end
 
   def request_headers do


### PR DESCRIPTION
This PR fixes config instructions for `:organization_key`, but also adds `OpenAI-Organization` header to the request properly.