### PR TITLE
Fixes #8 - request_options are being overwritten by api_post/3 defaults

### DIFF
--- a/lib/openai/client.ex
+++ b/lib/openai/client.ex
@@ -69,7 +69,7 @@ defmodule OpenAI.Client do
     |> handle_response()
   end
 
-  def multipart_api_post(url, file_path, params, request_options) do
+  def multipart_api_post(url, file_path, params, request_options \\ []) do
     body = {
       :multipart,
       # Very fragile, this interface doesn't work if given an empty tuple!

--- a/lib/openai/client.ex
+++ b/lib/openai/client.ex
@@ -79,6 +79,9 @@ defmodule OpenAI.Client do
       ] ++ if(tuple_size(params) != 0, do: [params], else: [])
     }
 
+    request_options =
+      Keyword.merge(request_options(), request_options)
+
     url
     |> post(body, [bearer()], request_options)
     |> handle_response()

--- a/lib/openai/client.ex
+++ b/lib/openai/client.ex
@@ -45,9 +45,12 @@ defmodule OpenAI.Client do
 
   def request_options(), do: Config.http_options()
 
-  def api_get(url) do
+  def api_get(url, request_options \\ []) do
+    request_options =
+      Keyword.merge(request_options(), request_options)
+
     url
-    |> get(request_headers(), request_options())
+    |> get(request_headers(), request_options)
     |> handle_response()
   end
 
@@ -58,8 +61,11 @@ defmodule OpenAI.Client do
       |> JSON.Encoder.encode()
       |> elem(1)
 
+    request_options =
+      Keyword.merge(request_options(), request_options)
+
     url
-    |> post(body, request_headers(), request_options || request_options())
+    |> post(body, request_headers(), request_options)
     |> handle_response()
   end
 


### PR DESCRIPTION
Fixes issue with defaults being persisted instead of picking up `http_options`.

Also added options to `api_get` for future use.