### PR TITLE
Add request options per request type

### DIFF
--- a/lib/openai/answers.ex
+++ b/lib/openai/answers.ex
@@ -6,8 +6,8 @@ defmodule OpenAI.Answers do
 
   def url(), do: @base_url
 
-  def fetch(params) do
+  def fetch(params, request_options \\ []) do
     url()
-    |> Client.api_post(params)
+    |> Client.api_post(params, request_options)
   end
 end

--- a/lib/openai/classifications.ex
+++ b/lib/openai/classifications.ex
@@ -6,8 +6,8 @@ defmodule OpenAI.Classifications do
 
   def url(), do: @base_url
 
-  def fetch(params) do
+  def fetch(params, request_options \\ []) do
     url()
-    |> Client.api_post(params)
+    |> Client.api_post(params, request_options)
   end
 end

--- a/lib/openai/client.ex
+++ b/lib/openai/client.ex
@@ -69,7 +69,7 @@ defmodule OpenAI.Client do
     |> handle_response()
   end
 
-  def multipart_api_post(url, file_path, params, request_options) do
+  def multipart_api_post(url, file_path, params, request_options \\ []) do
     body = {
       :multipart,
       # Very fragile, this interface doesn't work if given an empty tuple!

--- a/lib/openai/client.ex
+++ b/lib/openai/client.ex
@@ -79,6 +79,9 @@ defmodule OpenAI.Client do
       ] ++ if(tuple_size(params) != 0, do: [params], else: [])
     }
 
+    request_options =
+      Keyword.merge(request_options(), request_options)
+
     url
     |> post(body, [bearer()], request_options)
     |> handle_response()

--- a/lib/openai/client.ex
+++ b/lib/openai/client.ex
@@ -45,9 +45,12 @@ defmodule OpenAI.Client do
 
   def request_options(), do: Config.http_options()
 
-  def api_get(url) do
+  def api_get(url, request_options \\ []) do
+    request_options =
+      Keyword.merge(request_options(), request_options)
+
     url
-    |> get(request_headers(), request_options())
+    |> get(request_headers(), request_options)
     |> handle_response()
   end
 
@@ -58,8 +61,11 @@ defmodule OpenAI.Client do
       |> JSON.Encoder.encode()
       |> elem(1)
 
+    request_options =
+      Keyword.merge(request_options(), request_options)
+
     url
-    |> post(body, request_headers(), request_options || request_options())
+    |> post(body, request_headers(), request_options)
     |> handle_response()
   end
 

--- a/lib/openai/completions.ex
+++ b/lib/openai/completions.ex
@@ -6,8 +6,8 @@ defmodule OpenAI.Completions do
 
   def url(engine_id), do: "#{@base_url}/#{engine_id}/completions"
 
-  def fetch(engine_id, params) do
+  def fetch(engine_id, params, request_options \\ []) do
     url(engine_id)
-    |> Client.api_post(params)
+    |> Client.api_post(params, request_options)
   end
 end

--- a/lib/openai/search.ex
+++ b/lib/openai/search.ex
@@ -6,8 +6,8 @@ defmodule OpenAI.Search do
 
   def url(engine_id), do: "#{@base_url}/#{engine_id}/search"
 
-  def fetch(engine_id, params) do
+  def fetch(engine_id, params, request_options \\ []) do
     url(engine_id)
-    |> Client.api_post(params)
+    |> Client.api_post(params, request_options)
   end
 end


### PR DESCRIPTION
PR #5 added the ability to set http request options per request type in each module.  This PR restores that feature based on the fixes in #9.