### PR TITLE
chore: use `Jason.encode!/1` bang function

### DIFF
--- a/lib/openai/client.ex
+++ b/lib/openai/client.ex
@@ -57,8 +57,7 @@ defmodule OpenAI.Client do
     body =
       params
       |> Enum.into(%{})
-      |> Jason.encode()
-      |> elem(1)
+      |> Jason.encode!()
 
     request_options = Keyword.merge(request_options(), request_options)
 


### PR DESCRIPTION
I would suggest that is better to raise an exception here with `Jason.encode!/1` rather than relying on `elem(1)`.
Ideally we should handle errors, however this might be good enough ™️ 

Cheers!