### PR TITLE
Allow decode multiple response format in Transcriptions

### DIFF
--- a/lib/openai/client.ex
+++ b/lib/openai/client.ex
@@ -5,8 +5,22 @@ defmodule OpenAI.Client do
 
   def process_url(url), do: Config.api_url() <> url
 
-  def process_response_body(body) when is_map(body), do: Jason.decode(body)
-  def process_response_body(body) when is_binary(body), do: body
+  def process_response_body(body) do
+    try do
+      {status, res} = Jason.decode(body)
+
+      case status do
+        :ok ->
+          {:ok, res}
+
+        :error ->
+          body
+      end
+    rescue
+      _ ->
+        body
+    end
+  end
 
   def handle_response(httpoison_response) do
     case httpoison_response do


### PR DESCRIPTION
Allow binary response format for Audio Transcription with response format "vtt" or "srt".

How to test:

OpenAI.audio_transcription(
  "my_video.mp4",
  model: "whisper-1",
  response_format: "vtt",
  language: "en",
  temperature: "0"
)

OpenAI.audio_transcription(
  "my_video.mp4",
  model: "whisper-1",
  response_format: "json",
  language: "en",
  temperature: "0"
)