### PR TITLE
Per-request API headers for Completions

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,19 +108,22 @@ OpenAI.models("davinci-search-query")
 ```
 See: https://platform.openai.com/docs/api-reference/models/retrieve
 
-### completions(params)
+### completions(params, [additional_headers: ...] \\ [])
 It returns one or more predicted completions given a prompt.
-The function accepts as arguments the "engine_id" and the set of parameters used by the Completions OpenAI api
+The function accepts as arguments the set of parameters used by the Completions OpenAI api
+and optionally additional headers (e.g. an API key to use for just this request).
 
 #### Example request
 ```elixir
-  OpenAI.completions(
+  OpenAI.completions(%{
     model: "finetuned-model",
     prompt: "once upon a time",
     max_tokens: 5,
     temperature: 1,
     ...
-  )
+  }, additional_headers: [
+    {"Authorization", "Bearer PER_REQUEST_API_KEY"}
+  ])
 ```
 #### Example response
 ```elixir

--- a/lib/openai/client.ex
+++ b/lib/openai/client.ex
@@ -33,12 +33,18 @@ defmodule OpenAI.Client do
     end
   end
 
-  def request_headers do
+  def request_headers(additional_headers \\ []) do
     [
       bearer(),
       {"Content-type", "application/json"}
     ]
     |> add_organization_header()
+    |> then(fn headers ->
+      headers
+      |> Enum.into(%{})
+      |> Map.merge(Enum.into(additional_headers, %{}))
+      |> Enum.into([])
+    end)
   end
 
   def bearer(), do: {"Authorization", "Bearer #{Config.api_key()}"}
@@ -53,7 +59,7 @@ defmodule OpenAI.Client do
     |> handle_response()
   end
 
-  def api_post(url, params \\ [], request_options \\ []) do
+  def api_post(url, params \\ [], request_options \\ [], additional_headers \\ []) do
     body =
       params
       |> Enum.into(%{})
@@ -62,7 +68,7 @@ defmodule OpenAI.Client do
     request_options = Keyword.merge(request_options(), request_options)
 
     url
-    |> post(body, request_headers(), request_options)
+    |> post(body, request_headers(additional_headers), request_options)
     |> handle_response()
   end
 

--- a/lib/openai/completions.ex
+++ b/lib/openai/completions.ex
@@ -8,6 +8,11 @@ defmodule OpenAI.Completions do
   def deprecated_url(engine_id), do: "#{@engines_base_url}/#{engine_id}/completions"
   def url(), do: @base_url
 
+  def fetch(params, additional_headers: additional_headers) do
+    url()
+    |> Client.api_post(params, [], additional_headers)
+  end
+
   def fetch(engine_id, params) do
     deprecated_url(engine_id)
     |> Client.api_post(params)

--- a/lib/openai/images/generations.ex
+++ b/lib/openai/images/generations.ex
@@ -6,8 +6,8 @@ defmodule OpenAI.Images.Generations do
 
   def url(), do: @base_url
 
-  def fetch(params, request_options \\ [], additional_headers \\ []) do
+  def fetch(params, request_options \\ []) do
     url()
-    |> Client.api_post(params, additional_headers, request_options)
+    |> Client.api_post(params, request_options)
   end
 end

--- a/lib/openai/images/generations.ex
+++ b/lib/openai/images/generations.ex
@@ -6,8 +6,8 @@ defmodule OpenAI.Images.Generations do
 
   def url(), do: @base_url
 
-  def fetch(params, request_options \\ []) do
+  def fetch(params, request_options \\ [], additional_headers \\ []) do
     url()
-    |> Client.api_post(params, request_options)
+    |> Client.api_post(params, additional_headers, request_options)
   end
 end


### PR DESCRIPTION
 * Updates `Client.api_post/3` to take an optional keyword list of additional headers. These are merged (without duplication) in `request_headers`, with the additional headers taking precedence over defaults from `Config`.
 * Exposes additional headers in `Completions.fetch/2` public API

I think the current implementation will break if a call to (the deprecated) `Completions.fetch(engine_id, params)` method has a `params` argument containing a key called `additional_headers`, but outside of that I believe this is backwards compatible.

Closes #25 