### PR TITLE
Remove unused import Mock

### DIFF
--- a/test/openai_test.exs
+++ b/test/openai_test.exs
@@ -2,8 +2,6 @@ defmodule OpenaiTest do
   use ExUnit.Case
   doctest OpenAI
 
-  import Mock
-
   setup do
     [
       api_key: "123456789"


### PR DESCRIPTION
When running `mix test`, the warnings below are emitted:

```
warning: unused import Mock
  test/openai_test.exs:5
```