### PR TITLE
fix: config struct default values fallbacks

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Add ***:openai*** as a dependency in your mix.exs file.
 ```elixir
 def deps do
   [
-    {:openai, "~> 0.5.0"}
+    {:openai, "~> 0.5.1"}
   ]
 end
 ```

--- a/lib/openai/client.ex
+++ b/lib/openai/client.ex
@@ -44,8 +44,9 @@ defmodule OpenAI.Client do
   end
 
   def add_organization_header(headers, config) do
-    if Config.org_key() do
-      [{"OpenAI-Organization", config.organization_key} | headers]
+    org_key = config.organization_key || Config.org_key()
+    if org_key do
+      [{"OpenAI-Organization", org_key} | headers]
     else
       headers
     end
@@ -59,13 +60,13 @@ defmodule OpenAI.Client do
     |> add_organization_header(config)
   end
 
-  def bearer(config), do: {"Authorization", "Bearer #{config.api_key}"}
+  def bearer(config), do: {"Authorization", "Bearer #{config.api_key || Config.api_key()}"}
 
-  def request_options(config), do: config.http_options
+  def request_options(config), do: config.http_options || Config.http_options
 
   def api_get(url, config) do
     url
-    |> get(request_headers(config), config.http_options)
+    |> get(request_headers(config), request_options(config))
     |> handle_response()
   end
 
@@ -76,7 +77,7 @@ defmodule OpenAI.Client do
       |> Jason.encode!()
 
     url
-    |> post(body, request_headers(config), config.http_options)
+    |> post(body, request_headers(config), request_options(config))
     |> handle_response()
   end
 
@@ -92,13 +93,13 @@ defmodule OpenAI.Client do
     }
 
     url
-    |> post(body, request_headers(config), config.http_options)
+    |> post(body, request_headers(config), request_options(config))
     |> handle_response()
   end
 
   def api_delete(url, config) do
     url
-    |> delete(request_headers(config), config.http_options)
+    |> delete(request_headers(config), request_options(config))
     |> handle_response()
   end
 end

--- a/lib/openai/config.ex
+++ b/lib/openai/config.ex
@@ -4,18 +4,10 @@ defmodule OpenAI.Config do
   and caches the final config in memory to avoid parsing on each read afterwards.
   """
 
-  defstruct api_key:
-              :openai
-              |> Application.get_env(:api_key),
-            organization_key:
-              :openai
-              |> Application.get_env(:organization_key),
-            http_options:
-              :openai
-              |> Application.get_env(:http_options) || [],
-            api_url:
-              :openai
-              |> Application.get_env(:api_url)
+  defstruct api_key: nil,
+            organization_key: nil,
+            http_options: nil,
+            api_url: nil
 
   use GenServer
 

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Openai.MixProject do
   def project do
     [
       app: :openai,
-      version: "0.5.0",
+      version: "0.5.1",
       elixir: "~> 1.11",
       description: description(),
       start_permanent: Mix.env() == :prod,


### PR DESCRIPTION
v0.5.0 introduced an issue reported here: https://github.com/mgallo/openai.ex/issues/25#issuecomment-1518479304
the default values of the struct `OpenAI.Config` were only saved at compile time, causing problems with applications using the old version of the library. Fixed in this development by defaulting the configuration values correctly at runtime.