### PR TITLE
Server error handling

### DIFF
--- a/lib/openai/client.ex
+++ b/lib/openai/client.ex
@@ -35,6 +35,9 @@ defmodule OpenAI.Client do
       {:ok, %HTTPoison.Response{status_code: 200, body: body}} ->
         {:ok, body}
 
+      {:ok, %HTTPoison.Response{status_code: status_code, body: body}} ->
+        {:error, status_code}
+
       {:ok, %HTTPoison.Response{body: {:ok, body}}} ->
         {:error, body}
 
@@ -48,6 +51,7 @@ defmodule OpenAI.Client do
 
   def add_organization_header(headers, config) do
     org_key = config.organization_key || Config.org_key()
+
     if org_key do
       [{"OpenAI-Organization", org_key} | headers]
     else
@@ -65,7 +69,7 @@ defmodule OpenAI.Client do
 
   def bearer(config), do: {"Authorization", "Bearer #{config.api_key || Config.api_key()}"}
 
-  def request_options(config), do: config.http_options || Config.http_options
+  def request_options(config), do: config.http_options || Config.http_options()
 
   def api_get(url, config) do
     url
@@ -85,6 +89,7 @@ defmodule OpenAI.Client do
           url
           |> post(body, request_headers(config), request_options(config))
         end)
+
       false ->
         url
         |> post(body, request_headers(config), request_options(config))

--- a/lib/openai/client.ex
+++ b/lib/openai/client.ex
@@ -35,14 +35,15 @@ defmodule OpenAI.Client do
       {:ok, %HTTPoison.Response{status_code: 200, body: body}} ->
         {:ok, body}
 
-      {:ok, %HTTPoison.Response{status_code: status_code, body: body}} ->
-        {:error, status_code}
-
       {:ok, %HTTPoison.Response{body: {:ok, body}}} ->
         {:error, body}
 
       {:ok, %HTTPoison.Response{body: {:error, body}}} ->
         {:error, body}
+
+      # html error responses
+      {:ok, %HTTPoison.Response{status_code: status_code, body: body}} ->
+        {:error, %{status_code: status_code, body: body}}
 
       {:error, %HTTPoison.Error{reason: reason}} ->
         {:error, reason}

--- a/test/openai/client_test.exs
+++ b/test/openai/client_test.exs
@@ -1,0 +1,41 @@
+defmodule OpenAI.ClientTest do
+  use ExUnit.Case
+
+  @application :openai
+
+  describe "handle_response/1" do
+    test "correct responce" do
+      res =
+        {:ok,
+         %HTTPoison.Response{
+           body: "correct responce",
+           status_code: 200
+         }}
+        |> OpenAI.Client.handle_response()
+
+      assert {:ok, "correct responce"} = res
+    end
+
+    test "httpoison error" do
+      res =
+        {:error,
+         %HTTPoison.Error{
+           reason: "bad request"
+         }}
+        |> OpenAI.Client.handle_response()
+
+      assert {:error, "bad request"} = res
+    end
+
+    test "server error" do
+      res =
+        {:ok, %HTTPoison.Response{
+          body: "<html>\r\n<head><title>502 Bad Gateway</title></head>\r\n<body>\r\n<center><h1>502 Bad Gateway</h1></center>\r\n<hr><center>cloudflare</center>\r\n</body>\r\n</html>\r\n",
+          status_code: 502
+        }}
+        |> OpenAI.Client.handle_response()
+
+      assert {:error, 502} = res
+    end
+  end
+end

--- a/test/openai/client_test.exs
+++ b/test/openai/client_test.exs
@@ -1,41 +1,182 @@
 defmodule OpenAI.ClientTest do
   use ExUnit.Case
 
-  @application :openai
-
   describe "handle_response/1" do
-    test "correct responce" do
+    test "it should respond with success if HTTP status code 200 and the response is a JSON" do
       res =
         {:ok,
          %HTTPoison.Response{
-           body: "correct responce",
+           body:
+             {:ok,
+              %{
+                "text" =>
+                  "I've seen things you people wouldn't believe. Attack ships on fire off the shoulder of a lion. I watched sea beans glitter in the darkness for ten hours a day."
+              }},
+           headers: [],
+           request: %HTTPoison.Request{
+             body: "",
+             headers: [],
+             method: :get,
+             options: [],
+             params: %{},
+             url: "https://api.openai.com/v1/audio/transcriptions"
+           },
+           request_url: "https://api.openai.com/v1/audio/transcriptions",
            status_code: 200
          }}
         |> OpenAI.Client.handle_response()
 
-      assert {:ok, "correct responce"} = res
+      assert {:ok,
+              %{
+                text:
+                  "I've seen things you people wouldn't believe. Attack ships on fire off the shoulder of a lion. I watched sea beans glitter in the darkness for ten hours a day."
+              }} = res
     end
 
-    test "httpoison error" do
+    test "it should respond with success if HTTP status code 200 and the response is srt/vtt format" do
       res =
-        {:error,
-         %HTTPoison.Error{
-           reason: "bad request"
+        {:ok,
+         %HTTPoison.Response{
+           body:
+             "1\n00:00:00,000 --> 00:00:07,000\nI've seen things you people wouldn't believe.\n\n2\n00:00:08,000 --> 00:00:12,000\nAttack ships on fire off the shoulder of a lion.\n\n3\n00:00:12,000 --> 00:00:29,000\nI watched sea beans glitter in the darkness for ten hours a day.\n\n\n",
+           headers: [],
+           request: %HTTPoison.Request{
+             body: {:multipart, []},
+             headers: [],
+             method: :post,
+             options: [],
+             params: %{},
+             url: "https://api.openai.com/v1/audio/transcriptions"
+           },
+           request_url: "https://api.openai.com/v1/audio/transcriptions",
+           status_code: 200
          }}
         |> OpenAI.Client.handle_response()
 
-      assert {:error, "bad request"} = res
+      assert {:ok,
+              "1\n00:00:00,000 --> 00:00:07,000\nI've seen things you people wouldn't believe.\n\n2\n00:00:08,000 --> 00:00:12,000\nAttack ships on fire off the shoulder of a lion.\n\n3\n00:00:12,000 --> 00:00:29,000\nI watched sea beans glitter in the darkness for ten hours a day.\n\n\n"} =
+               res
     end
 
-    test "server error" do
+    test "it should handle json errors (HTTP Error code 404)" do
       res =
-        {:ok, %HTTPoison.Response{
-          body: "<html>\r\n<head><title>502 Bad Gateway</title></head>\r\n<body>\r\n<center><h1>502 Bad Gateway</h1></center>\r\n<hr><center>cloudflare</center>\r\n</body>\r\n</html>\r\n",
-          status_code: 502
-        }}
+        {:ok,
+         %HTTPoison.Response{
+           body:
+             {:ok,
+              %{
+                "error" => %{
+                  "code" => nil,
+                  "message" => "No such File object: asd",
+                  "param" => "id",
+                  "type" => "invalid_request_error"
+                }
+              }},
+           headers: [],
+           request: %HTTPoison.Request{
+             body: "",
+             headers: [],
+             method: :get,
+             options: [],
+             params: %{},
+             url: "https://api.openai.com/v1/files/asd"
+           },
+           request_url: "https://api.openai.com/v1/files/asd",
+           status_code: 404
+         }}
         |> OpenAI.Client.handle_response()
 
-      assert {:error, 502} = res
+      assert {:error,
+              %{
+                "error" => %{
+                  "code" => nil,
+                  "message" => "No such File object: asd",
+                  "param" => "id",
+                  "type" => "invalid_request_error"
+                }
+              }} = res
+    end
+
+    test "it should handle json errors (HTTP Error code 400)" do
+      res =
+        {:ok,
+         %HTTPoison.Response{
+           body:
+             {:ok,
+              %{
+                "error" => %{
+                  "code" => nil,
+                  "message" => "you must provide a model parameter",
+                  "param" => nil,
+                  "type" => "invalid_request_error"
+                }
+              }},
+           headers: [],
+           request: %HTTPoison.Request{
+             body:
+               {:multipart,
+                [
+                  {:file, "./config/bladerunner.mp3",
+                   {"form-data", [name: "file", filename: "bladerunner.mp3"]}, []},
+                  {"models", "whisper-1"},
+                  {"response_formats", "srt"}
+                ]},
+             headers: [],
+             method: :post,
+             options: [],
+             params: %{},
+             url: "https://api.openai.com/v1/audio/transcriptions"
+           },
+           request_url: "https://api.openai.com/v1/audio/transcriptions",
+           status_code: 400
+         }}
+        |> OpenAI.Client.handle_response()
+
+      assert {:error,
+              %{
+                "error" => %{
+                  "code" => nil,
+                  "message" => "you must provide a model parameter",
+                  "param" => nil,
+                  "type" => "invalid_request_error"
+                }
+              }} = res
+    end
+
+    test "it should handle html errors (sometimes openai answer with HTTP Error code 502 and cloudflare / nginx error)" do
+      res =
+        {:ok,
+         %HTTPoison.Response{
+           body:
+             "<html>\r\n<head><title>502 Bad Gateway</title></head>\r\n<body>\r\n<center><h1>502 Bad Gateway</h1></center>\r\n<hr><center>cloudflare</center>\r\n</body>\r\n</html>\r\n",
+           status_code: 502
+         }}
+        |> OpenAI.Client.handle_response()
+
+      assert {:error,
+              %{
+                body:
+                  "<html>\r\n<head><title>502 Bad Gateway</title></head>\r\n<body>\r\n<center><h1>502 Bad Gateway</h1></center>\r\n<hr><center>cloudflare</center>\r\n</body>\r\n</html>\r\n",
+                status_code: 502
+              }} = res
+    end
+
+    test "it should handle 503 nginx errors (sometimes openai answer with HTTP Error code 503)" do
+      res =
+        {:ok,
+         %HTTPoison.Response{
+           status_code: 503,
+           body:
+             {:error,
+              {:unexpected_token,
+               "<html>\r\n<head><title>503 Service Temporarily Unavailable</title></head>\r\n<body>\r\n<center><h1>503 Service Temporarily Unavailable</h1></center>\r\n<hr><center>nginx</center>\r\n</body>\r\n</html>"}}
+         }}
+        |> OpenAI.Client.handle_response()
+
+      assert {:error,
+              {:unexpected_token,
+               "<html>\r\n<head><title>503 Service Temporarily Unavailable</title></head>\r\n<body>\r\n<center><h1>503 Service Temporarily Unavailable</h1></center>\r\n<hr><center>nginx</center>\r\n</body>\r\n</html>"}} =
+               res
     end
   end
 end


### PR DESCRIPTION
Open AI server responded with 502 error. Service crashed with:

```
** (CaseClauseError) no case clause matching: 
  {:ok, %HTTPoison.Response{
    status_code: 502, 
    body: "<html>\r\n<head><title>502 Bad Gateway</title></head>\r\n<body>\r\n<center><h1>502 Bad Gateway</h1></center>\r\n<hr><center>cloudflare</center>\r\n</body>\r\n</html>\r\n", 
    headers: [
      ...
    ], 
    request_url: "https://api.openai.com/v1/chat/completions", 
    request: %HTTPoison.Request{
      ...
    }
  }}
(openai 0.5.2) lib/openai/client.ex:26: OpenAI.Client.handle_response/1
```

Added needed clause and some tests