### PR TITLE
Handle HTTPoison error case during Stream.new/1 - Fixes #51

### DIFF
--- a/lib/openai/stream.ex
+++ b/lib/openai/stream.ex
@@ -4,53 +4,68 @@ defmodule OpenAI.Stream do
   def new(start_fun) do
     Stream.resource(
       start_fun,
-      fn res ->
-        {res, id} = case res do
-          {:ok, res = %HTTPoison.AsyncResponse{id: id}} -> {res, id}
-          res = %HTTPoison.AsyncResponse{id: id} -> {res, id}
-        end
+      fn
+        {:error, %HTTPoison.Error{} = error} ->
+          {
+            [
+              %{
+                "status" => :error,
+                "reason" => error.reason,
+              }
+            ],
+            error
+          }
 
-        receive do
-          %HTTPoison.AsyncStatus{id: ^id, code: code} ->
-            HTTPoison.stream_next(res)
-            case code do
-              200 ->
-                {[], res}
-              _ ->
-                {
-                  [
-                    %{
-                      "status" => :error,
-                      "code" => code,
-                      "choices" => []
-                    }
-                  ],
-                  res
-                }
-            end
-          %HTTPoison.AsyncHeaders{id: ^id, headers: _headers}->
-            HTTPoison.stream_next(res)
-            {[], res}
-          %HTTPoison.AsyncChunk{chunk: chunk}->
-            data =
-              chunk
-              |> String.split("\n")
-              |> Enum.filter(fn line ->
-                String.starts_with?(line, "data: {")
-              end)
-              |> Enum.map(fn line ->
-                line
-                |> String.replace_prefix("data: ", "")
-                |> Jason.decode!()
-              end)
+        %HTTPoison.Error{} = error ->
+          {:halt, error}
 
-            HTTPoison.stream_next(res)
-            {data, res}
-          %HTTPoison.AsyncEnd{}->
-            {:halt, res}
-        end
+        res ->
+          {res, id} = case res do
+            {:ok, res = %HTTPoison.AsyncResponse{id: id}} -> {res, id}
+            res = %HTTPoison.AsyncResponse{id: id} -> {res, id}
+          end
+
+          receive do
+            %HTTPoison.AsyncStatus{id: ^id, code: code} ->
+              HTTPoison.stream_next(res)
+              case code do
+                200 ->
+                  {[], res}
+                _ ->
+                  {
+                    [
+                      %{
+                        "status" => :error,
+                        "code" => code,
+                        "choices" => []
+                      }
+                    ],
+                    res
+                  }
+              end
+            %HTTPoison.AsyncHeaders{id: ^id, headers: _headers}->
+              HTTPoison.stream_next(res)
+              {[], res}
+            %HTTPoison.AsyncChunk{chunk: chunk}->
+              data =
+                chunk
+                |> String.split("\n")
+                |> Enum.filter(fn line ->
+                  String.starts_with?(line, "data: {")
+                end)
+                |> Enum.map(fn line ->
+                  line
+                  |> String.replace_prefix("data: ", "")
+                  |> Jason.decode!()
+                end)
+
+              HTTPoison.stream_next(res)
+              {data, res}
+            %HTTPoison.AsyncEnd{}->
+              {:halt, res}
+          end
       end,
-      fn %HTTPoison.AsyncResponse{id: id} ->
+      fn %{id: id} ->
         id |> :hackney.stop_async()
       end
     )

--- a/test/openai/stream_test.exs
+++ b/test/openai/stream_test.exs
@@ -1,0 +1,15 @@
+defmodule OpenAI.StreamTest do
+  use ExUnit.Case
+
+  describe "new/1" do
+    test "handles error" do
+      results =
+        OpenAI.Stream.new(fn ->
+          HTTPoison.get("http://nxdomain-error/", [], stream_to: self(), async: :once)
+        end)
+        |> Enum.to_list()
+
+      assert [%{"reason" => :nxdomain, "status" => :error}] == results
+    end
+  end
+end


### PR DESCRIPTION
Per #51 - fix FunctionClauseError when starting an async stream.  Adds error handling for `%HTTPoison.Error{}` to `OpenAI.Stream.new/1`.