### PR TITLE
Can pass custom headers to config. Allow using alternative endpoints configuration

### DIFF
--- a/lib/openai/client.ex
+++ b/lib/openai/client.ex
@@ -3,7 +3,7 @@ defmodule OpenAI.Client do
   alias OpenAI.{Config, Stream}
   use HTTPoison.Base
 
-  def process_url(url), do: Config.api_url() <> url
+  def process_url(url), do: Config.api_url(url)
 
   def process_response_body(body) do
     try do
@@ -85,6 +85,16 @@ defmodule OpenAI.Client do
   end
 
   def api_post(url, params \\ [], config) do
+    IO.inspect config, label: "API_POST_CONFIG"
+
+    url = case config.api_url do
+      nil ->
+        url
+
+      _ ->
+        config.api_url <> url
+    end
+
     body =
       params
       |> Enum.into(%{})

--- a/lib/openai/config.ex
+++ b/lib/openai/config.ex
@@ -17,7 +17,8 @@ defmodule OpenAI.Config do
   @config_keys [
     :api_key,
     :organization_key,
-    :http_options
+    :http_options,
+    :api_url
   ]
 
   def start_link(opts), do: GenServer.start_link(__MODULE__, opts, name: __MODULE__)
@@ -38,6 +39,14 @@ defmodule OpenAI.Config do
 
   # API Url
   def api_url, do: get_config_value(:api_url, @openai_url)
+
+  def api_url(url) do
+    uri = URI.parse(url)
+    case uri.host do
+      nil -> api_url() <> url
+      _ -> url
+    end
+  end
 
   # HTTP Options
   def http_options, do: get_config_value(:http_options, [])


### PR DESCRIPTION
I needed to modify the code to be able to use OpenRouter ( and access GPT 4 32k ).
We can now use custom_headers in the config to add custom headers this way:

```
config :openai,                                                                                               
   api_key: "...", 
   organization_key: "...",                                                     
   http_options: [...],                                                                
   api_url: "https://openrouter.ai/api",                                                                 
   custom_headers: [                                                                                     
       {"HTTP-Referer", "https://example.com/"},                                                      
       {"X-Title", "MyService" }                                                                           
   ]
```

Note: this is my first open source contribution ever. Not sure I'm following the proper etiquette and process.