### PR TITLE
Add support for Audio/Create Speech

### DIFF
--- a/README.md
+++ b/README.md
@@ -505,6 +505,24 @@ OpenAI.embeddings(
 ```
 See: https://platform.openai.com/docs/api-reference/embeddings/create
 
+### audio_speech(params)
+Generates audio from the input text.
+
+#### Example request
+```elixir
+OpenAI.audio_speech(
+  model: "tts-1",
+  input: "You know that Voight-Kampf test of yours. Did you ever take that test yourself?",
+  voice: "alloy"
+)
+```
+
+#### Example response
+```elixir
+  {:ok, <<255, 255, ...>>}
+```
+
+See: https://platform.openai.com/docs/api-reference/audio/create to get info on the params accepted by the api
 
 ### audio_transcription(file_path, params)
 Transcribes audio into the input language.

--- a/lib/openai.ex
+++ b/lib/openai.ex
@@ -359,6 +359,25 @@ defmodule OpenAI do
   end
 
   @doc """
+  Generates audio from the input text.
+
+  ## Example request
+  OpenAI.audio_speech(
+    model: "tts-1",
+    input: "You know that Voight-Kampf test of yours. Did you ever take that test yourself?",
+    voice: "alloy"
+  )
+
+  ## Example response
+  {:ok, <<255, 255, ...>>}
+  
+  See: https://platform.openai.com/docs/api-reference/audio/create
+  """
+  def audio_speech(params, config \\ %Config{}) do
+    Audio.speech(params, config)
+  end
+
+  @doc """
   Transcribes audio into the input language.
   
   ## Example request

--- a/lib/openai/audio.ex
+++ b/lib/openai/audio.ex
@@ -4,8 +4,14 @@ defmodule OpenAI.Audio do
   alias OpenAI.Config
 
   @base_url "/v1/audio"
+  def speech_url(), do: "#{@base_url}/speech"
   def transcriptions_url(), do: "#{@base_url}/transcriptions"
   def translations_url(), do: "#{@base_url}/translations"
+
+  def speech(params, config \\ %Config{}) do
+    speech_url()
+    |> Client.api_post(params, config)
+  end
 
   def transcription(file_path, params, config \\ %Config{}) do
     transcriptions_url()


### PR DESCRIPTION
# Summary
This pull request introduces the new Audio/Create Speech endpoint for Text-to-speech (TTS).

# Motivation & Context
[OpenAI introduced a whole bunch of new APIs from their Dev Day this week.](https://openai.com/blog/new-models-and-developer-products-announced-at-devday)
The Audio/Create Speech is one such endpoint which generates audio from the input text.
I was looking into it for work and saw it wasn't implemented, so I'm sharing changes I did locally.

# Changes
- [x] Added `OpenAI.Audio.speech/2`
- [x] Added `OpenAI.audio_speech/2`
- [x] Updated README.md with examples on `OpenAI.audio_speech/2`  

# How to Test
## Livebook
1. Create a new livebook or use [this](https://github.com/shawnleong/openai_ex_livebooks/blob/3b60de9d73037dfc7447a618b066edca7b92290e/openai_ex_audio_speech.livemd)
2. Install these following dependencies
	```elixir
	Mix.install([
	  {:openai, path: "path/to/mix/directory/openai.ex"},
	  {:kino, "~> 0.11.2"}
	])
	```
3.  Config
```elixir
	openai_config = %OpenAI.Config{
	  api_key: System.get_env("OPENAI_API_KEY"),
	  organization_key: System.get_env("OPENAI_ORGANIZATION_KEY"),
	  http_options: [recv_timeout: :infinity]
	}
```
4. Request with the new endpoint
```elixir
	{:ok, binary} = 
	  OpenAI.audio_speech([
	    input: "You know that Voight-Kampf test of yours. Did you ever take that test yourself?", 
	    model: "tts-1", voice: "alloy"
	  ], openai_config)
```
5. Consume the binary with `Kino.Audio.new/2`
```elixir
	Kino.Audio.new(binary, :mp3)
```
# Screenshots
![image](https://github.com/mgallo/openai.ex/assets/17049613/7f2f5e19-9317-49f5-96bc-cb2b6f239b5a)

# Other
- I'm not sure if this endpoint supports streaming the response audio file content. Don't see a mention or parameters indicating that in the docs.
- Happy to help contribute to the remaining new beta endpoints after/if this is merged. Thanks!