### PR TITLE
Fix return headers for non-stream chat completion [sc-50742]

### DIFF
--- a/lib/openai/client.ex
+++ b/lib/openai/client.ex
@@ -24,26 +24,26 @@ defmodule OpenAI.Client do
 
   def handle_response(httpoison_response) do
     case httpoison_response do
-      {:ok, %HTTPoison.Response{status_code: 200, body: {:ok, body}}} ->
+      {:ok, %HTTPoison.Response{status_code: 200, body: {:ok, body}, headers: headers}} ->
         res =
           body
           |> Enum.map(fn {k, v} -> {String.to_atom(k), v} end)
           |> Map.new()
 
-        {:ok, res}
+        {:ok, res, headers}
 
-      {:ok, %HTTPoison.Response{status_code: 200, body: body}} ->
-        {:ok, body}
+      {:ok, %HTTPoison.Response{status_code: 200, body: body, headers: headers}} ->
+        {:ok, body, headers}
 
-      {:ok, %HTTPoison.Response{body: {:ok, body}}} ->
-        {:error, body}
+      {:ok, %HTTPoison.Response{body: {:ok, body}, headers: headers}} ->
+        {:error, body, headers}
 
-      {:ok, %HTTPoison.Response{body: {:error, body}}} ->
-        {:error, body}
+      {:ok, %HTTPoison.Response{body: {:error, body}, headers: headers}} ->
+        {:error, body, headers}
 
       # html error responses
-      {:ok, %HTTPoison.Response{status_code: status_code, body: body}} ->
-        {:error, %{status_code: status_code, body: body}}
+      {:ok, %HTTPoison.Response{status_code: status_code, body: body, headers: headers}} ->
+        {:error, %{status_code: status_code, body: body, headers: headers}}
 
       {:error, %HTTPoison.Error{reason: reason}} ->
         {:error, reason}

--- a/lib/openai/sse_stream_parser.ex
+++ b/lib/openai/sse_stream_parser.ex
@@ -34,6 +34,9 @@ defmodule OpenAI.SSEStreamParser do
         {code, chunk}, acc when is_integer(code) ->
           {[], acc <> chunk}
 
+        {:header, chunk}, acc ->
+          {[chunk], acc}
+
         {:error, error}, acc ->
           {[error], acc}
       end,

--- a/lib/openai/stream.ex
+++ b/lib/openai/stream.ex
@@ -32,9 +32,9 @@ defmodule OpenAI.Stream do
             # We should be able to tell the difference between an error and the
             # event stream with content-type (text/event-stream), but
             # unfortunately OpenAI doesn't obey the spec.
-            %HTTPoison.AsyncHeaders{id: ^id, headers: _headers} ->
+            %HTTPoison.AsyncHeaders{id: ^id, headers: _headers} = header ->
               HTTPoison.stream_next(res)
-              {[], {code, res}}
+              {[{:header, header}], {code, res}}
 
             %HTTPoison.AsyncChunk{chunk: chunk} ->
               HTTPoison.stream_next(res)


### PR DESCRIPTION
When doing non-stream chat_completion, we need access to the headers as well.